### PR TITLE
feat: Add option to handle breakpoints as desktop-first instead of the default mobile-first.

### DIFF
--- a/packages/docs/guide/settings.md
+++ b/packages/docs/guide/settings.md
@@ -29,6 +29,7 @@
 | [pauseOnFocus](#pauseonfocus)                             | Boolean | `true`       | Pause autoplay on focus.                                 |
 | [pauseOnHover](#pauseonhover)                             | Boolean | `true`       | Pause autoplay on hover.                                 |
 | [prevArrowLabel](#prevarrowlabel)                         | String  | `'Previous'` | Previous arrow label.                                    |
+| [responsiveBehavior](#responsiveBehavior)                 | String  | `'mobile-first'`| How responsive queries behave                         |
 | [responsive](#responsive)                                 | Array   | `[]`         | Responsive settings.                                     |
 | [rtl](#rtl)                                               | Boolean | `false`      | Enable right-to-left mode.                               |
 | [slidesPerGroup](#slidespergroup)                         | Number  | `1`          | Number of slides per group.                              |
@@ -204,6 +205,15 @@ Pause autoplay on hover. See [Auto Play](/examples/auto-play) example.
 <small>Default: `'Previous'`</small>
 
 Previous arrow label (for accessibility).
+
+## `responsiveBehavior` <Badge type="info" text="array" />
+
+<small>Default: `'mobile-first'`</small>
+
+Defines how to apply responsive settings.
+
+With `'mobile-first'` the default settings are for mobile view and the responsive options apply for the repestive breakpoints as a `'min-width'` rule.
+With `'desktop-first'` the default settings are for desktop view and the responsive options apply for the respective breakpoints as a `'max-width'` rule.
 
 ## `responsive` <Badge type="info" text="array" />
 

--- a/packages/v-slick-carousel/lib/components/VSlickCarousel.vue
+++ b/packages/v-slick-carousel/lib/components/VSlickCarousel.vue
@@ -231,20 +231,35 @@ const clearBreakpoints = () => {
 
 const makeBreakpoints = () => {
   if (!props.responsive.length) return
+
+  let mediaQueryLimit: string = 'min-width'
+  if (props.responsiveBehavior === 'desktop-first') {
+    mediaQueryLimit = 'max-width'
+  }
+
   const breakpoints = props.responsive.map((item) => item.breakpoint)
   breakpoints.sort((a, b) => a - b)
   breakpoints.forEach((_breakpoint, index) => {
     const mediaQuery = json2mq({
-      'min-width': `${_breakpoint}px`
+      [mediaQueryLimit]: `${_breakpoint}px`
     })
+
+    const desktopPreviousHandler = () => {
+      breakpoint.value =
+        index === breakpoints.length - 1 ? undefined : breakpoints[index + 1]
+    }
+    const mobilePreviousHandler = () => {
+      breakpoint.value = index === 0 ? undefined : breakpoints[index + 1]
+    }
+
     media(
       mediaQuery,
       () => {
         breakpoint.value = _breakpoint
       },
-      () => {
-        breakpoint.value = index === 0 ? undefined : breakpoints[index - 1]
-      }
+      props.responsiveBehavior === 'desktop-first'
+        ? desktopPreviousHandler
+        : mobilePreviousHandler
     )
   })
 }

--- a/packages/v-slick-carousel/lib/components/props.ts
+++ b/packages/v-slick-carousel/lib/components/props.ts
@@ -45,6 +45,10 @@ const makeDefaultProps = (selectFields?: string[]) => {
     pauseOnHover: { type: Boolean, default: true },
     prevArrowLabel: { type: String, default: 'Previous' },
     responsive: { type: Array as PropType<Responsive[]>, default: [] },
+    responsiveBehavior: {
+      type: String as PropType<'mobile-first' | 'desktop-first'>,
+      default: 'mobile-first'
+    },
     rtl: { type: Boolean, default: false },
     slidesPerGroup: { type: Number, default: 1 },
     groupsToScroll: { type: Number, default: 1 },

--- a/packages/v-slick-carousel/lib/types/carousel.ts
+++ b/packages/v-slick-carousel/lib/types/carousel.ts
@@ -39,6 +39,7 @@ export type Props = {
   pauseOnFocus: boolean
   pauseOnHover: boolean
   prevArrowLabel?: string
+  responsiveBehavior: 'mobile-first' | 'desktop-first'
   responsive: Responsive[]
   rtl: boolean
   slidesPerGroup: number


### PR DESCRIPTION
I added a new option to specify how to handle the responsive breakpoint rules. By default is keeps the mobile-first approach defining min-width rules. But changing the new prop to "desktop-first" makes it create the rules as max-width and also handling the media handlers to change accordingly when adjusting the viewport width.